### PR TITLE
Check isSpeaking for remote participant after speaking event triggered

### DIFF
--- a/AzureCalling/app/src/main/java/com/azure/samples/communication/calling/external/calling/CallingContext.java
+++ b/AzureCalling/app/src/main/java/com/azure/samples/communication/calling/external/calling/CallingContext.java
@@ -481,7 +481,9 @@ public class CallingContext {
         final String username = remoteParticipant.getDisplayName();
         final String id = getId(remoteParticipant);
         final PropertyChangedListener remoteIsSpeakingChangedListener = propertyChangedEvent -> {
-            if (displayedRemoteParticipantIds.contains(id)) {
+            // skip the participants who is already on the screen and
+            // check if participant is still speaking to reduce unnecessary speaking changes due to noise
+            if (displayedRemoteParticipantIds.contains(id) || !remoteParticipant.isSpeaking()) {
                 return;
             }
             findInactiveSpeakerToSwap(remoteParticipant, id);


### PR DESCRIPTION
Since the speaking change event is currently raised every time a sound is detected/not through the mic. We want to double check if the remote participant whose event being triggered is speaking or not before making any participants' view update.

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[X] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```
