### PR TITLE
Remove Call Agent recreation workaround

### DIFF
--- a/AzureCalling/app/src/main/java/com/azure/samples/communication/calling/external/calling/CallingContext.java
+++ b/AzureCalling/app/src/main/java/com/azure/samples/communication/calling/external/calling/CallingContext.java
@@ -105,23 +105,17 @@ public class CallingContext {
     public CompletableFuture<Void> setupAsync() {
         // Initialize CompletableFutures
         setupCompletableFuture = new CompletableFuture<>();
-        communicationUserCredentialCompletableFuture = new CompletableFuture<>();
-        callAgentCompletableFuture = new CompletableFuture<>();
         deviceManagerCompletableFuture = new CompletableFuture<>();
         initializeCameraCompletableFuture = new CompletableFuture<>();
 
         // Define completion code for setup
         createCallClient();
-        createTokenCredential();
-        createCallAgent(null);
         createDeviceManager();
         initializeCamera();
         initializeSpeaker();
 
         // Wait until everything except localVideoStream is ready to define setup ready
         CompletableFuture.allOf(
-                communicationUserCredentialCompletableFuture,
-                callAgentCompletableFuture,
                 deviceManagerCompletableFuture,
                 initializeCameraCompletableFuture).whenComplete((aVoid, throwable) -> {
                     setupCompletableFuture.complete(aVoid);
@@ -166,7 +160,6 @@ public class CallingContext {
      * Join a call
      */
     public CompletableFuture<Void> joinCallAsync(final JoinCallConfig joinCallConfig) {
-        // Recreate Token and Call Agent as a work-around
         communicationUserCredentialCompletableFuture = new CompletableFuture<>();
         callAgentCompletableFuture = new CompletableFuture<>();
         createTokenCredential();
@@ -277,11 +270,8 @@ public class CallingContext {
     }
 
     private void createDeviceManager() {
-        callAgentCompletableFuture.whenComplete((callAgent, throwable) -> {
-            Log.d(LOG_TAG, "Call Agent created");
-            callClient.getDeviceManager(appContext).thenAccept(deviceManager -> {
-                deviceManagerCompletableFuture.complete(deviceManager);
-            });
+        callClient.getDeviceManager(appContext).thenAccept(deviceManager -> {
+            deviceManagerCompletableFuture.complete(deviceManager);
         });
     }
 
@@ -314,18 +304,13 @@ public class CallingContext {
 
     private void createCallAgent(final String userName) {
         communicationUserCredentialCompletableFuture.whenComplete((communicationUserCredential, throwable) -> {
-            final CompletableFuture<CallAgent> completableFuture;
-            if (userName != null) {
-                displayName = userName;
-                final CallAgentOptions options = new CallAgentOptions();
-                options.setDisplayName(userName);
-                completableFuture = callClient.createCallAgent(appContext, communicationUserCredential, options);
-            } else {
-                completableFuture = callClient.createCallAgent(appContext, communicationUserCredential);
-            }
-            completableFuture.whenComplete((callAgent, callAgentThrowable) -> {
-                callAgentCompletableFuture.complete(callAgent);
-            });
+            displayName = userName;
+            final CallAgentOptions options = new CallAgentOptions();
+            options.setDisplayName(userName);
+            callClient.createCallAgent(appContext, communicationUserCredential, options)
+                    .whenComplete((callAgent, callAgentThrowable) -> {
+                        callAgentCompletableFuture.complete(callAgent);
+                    });
         });
     }
 


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* Remove having to create the Call Agent in order to create the Device Manager

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
*  Get the code

## What to Check
* Basic turning on and off of Video in the Setup Activity works
* 1:1 and Group Calling work with Video on and off
