### PR TITLE
Fix Hangup Overlay Tap to Dismiss - Prevent Triggering Other TouchListeners

### DIFF
--- a/AzureCalling/app/src/main/java/com/azure/samples/communication/calling/activities/CallActivity.java
+++ b/AzureCalling/app/src/main/java/com/azure/samples/communication/calling/activities/CallActivity.java
@@ -526,9 +526,6 @@ public class CallActivity extends AppCompatActivity {
 
         gridLayout.setOnTouchListener((v, event) -> {
             if (event.getAction() == MotionEvent.ACTION_UP) {
-                // close hangup dialog if open
-                closeHangupDialog();
-
                 toggleParticipantHeaderNotification();
                 return true;
             }
@@ -536,6 +533,10 @@ public class CallActivity extends AppCompatActivity {
         });
 
         callHangupOverlay = findViewById(R.id.call_hangup_overlay);
+        callHangupOverlay.setOnTouchListener((v, event) -> {
+            closeHangupDialog();
+            return true;
+        });
     }
 
     private void setupGridLayout() {

--- a/AzureCalling/app/src/main/res/layout-land/activity_call.xml
+++ b/AzureCalling/app/src/main/res/layout-land/activity_call.xml
@@ -120,8 +120,10 @@
         android:background="#CC000000"
         android:gravity="center"
         android:orientation="vertical"
+        android:clickable="true"
+        android:focusable="true"
         app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toStartOf="@id/call_buttons"
+        app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent"
         tools:visibility="invisible">

--- a/AzureCalling/app/src/main/res/layout/activity_call.xml
+++ b/AzureCalling/app/src/main/res/layout/activity_call.xml
@@ -120,6 +120,8 @@
         android:background="#CC000000"
         android:gravity="center"
         android:orientation="vertical"
+        android:clickable="true"
+        android:focusable="true"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"


### PR DESCRIPTION
Fix a bug for hangup overlay to prevent buttons from being triggered unexpectedly when the hangup overlay is up.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[X] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```
