### PR TITLE
Changed CallActivity launchMode from singleTop -> singleTask

### DIFF
--- a/AzureCalling/app/src/main/AndroidManifest.xml
+++ b/AzureCalling/app/src/main/AndroidManifest.xml
@@ -55,7 +55,7 @@
             android:configChanges="orientation|screenSize|screenLayout"
             android:parentActivityName="com.azure.samples.communication.calling.activities.SetupActivity"
             android:screenOrientation="sensor"
-            android:launchMode="singleTop"/>
+            android:launchMode="singleTask"/>
         <activity
             android:name="com.azure.samples.communication.calling.activities.SetupActivity"
             android:exported="true"


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* On first app run before video permissions are set, during a call, tapping video to display the permission dialogue, then going to background and returning via Notification Tray would trigger CallActivity.onCreate(), since the previous launchMode was singleTop, which would do so, since the top task was the permission dialogue instead of CallActivity itself.
* This fix calls CallActivity.onResume() properly, which prevents a crash

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What to Check
Verify that the following are valid
* Uninstall app, reinstall
* Go into call before video permission are set
* Tap Camera button to display Camera permissions dialogue
* Minimize app
* Re-open app via Notification Tray
* Note that the app does not crash

## Other Information
<!-- Add any other helpful information that may be needed here. -->