### PR TITLE
Fix app restarts when opening via app icon

### DIFF
--- a/AzureCalling/app/src/main/AndroidManifest.xml
+++ b/AzureCalling/app/src/main/AndroidManifest.xml
@@ -73,8 +73,7 @@
         <activity
             android:name="com.azure.samples.communication.calling.activities.IntroActivity"
             android:launchMode="singleTop"
-            android:screenOrientation="portrait"
-            android:alwaysRetainTaskState="true">
+            android:screenOrientation="portrait">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />

--- a/AzureCalling/app/src/main/AndroidManifest.xml
+++ b/AzureCalling/app/src/main/AndroidManifest.xml
@@ -73,7 +73,8 @@
         <activity
             android:name="com.azure.samples.communication.calling.activities.IntroActivity"
             android:launchMode="singleTop"
-            android:screenOrientation="portrait">
+            android:screenOrientation="portrait"
+            android:alwaysRetainTaskState="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />

--- a/AzureCalling/app/src/main/java/com/azure/samples/communication/calling/activities/IntroActivity.java
+++ b/AzureCalling/app/src/main/java/com/azure/samples/communication/calling/activities/IntroActivity.java
@@ -33,6 +33,16 @@ public class IntroActivity extends AppCompatActivity {
     @Override
     protected void onCreate(final Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
+
+        if (!isTaskRoot()
+                && getIntent().hasCategory(Intent.CATEGORY_LAUNCHER)
+                && getIntent().getAction() != null
+                && getIntent().getAction().equals(Intent.ACTION_MAIN)) {
+
+            finish();
+            return;
+        }
+        
         setContentView(R.layout.activity_intro);
 
         // Get a support ActionBar corresponding to this toolbar


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* When the app is side-loaded and Opened via the Post-installation dialog, this launching mechanism of the app is different from the launching mechanism that the Launcher will use (When you tap on the Icon to open the app)
* As a result, opening the app in a post-installation context, and then minimizing the app, and re-opening it again via Launcher will open a new copy of the app on top of the first one.
* https://stackoverflow.com/a/23220151 describe this behaviour as an on-going bug, and a work-around is suggested to handle this unwanted new copy of the app.
* This bad behaviour will only occur on the very first launch of the app, and will behave properly once it gets launched in a normal manner.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What to Check
Verify that the following are valid
* Create an unsigned APK of the app, or create a signed APK via release pipeline in Azure Devops
* Install the app via side-loading (Installing the APK directly from the Android Files app)
* Upon installation, tap on "Open" to open the app directly from the installation dialog
* Go to any activity other than the Intro one (Setup, Join, Call)
* Minimize the app
* Re-open the app via the Launcher (The regular app drawer)
* Note that you are not returned to the IntroActivity

## Other Information
<!-- Add any other helpful information that may be needed here. -->