### PR TITLE
Handle the call state change for new released SDK

### DIFF
--- a/AzureCalling/app/src/main/java/com/azure/samples/communication/calling/activities/CallActivity.java
+++ b/AzureCalling/app/src/main/java/com/azure/samples/communication/calling/activities/CallActivity.java
@@ -141,11 +141,13 @@ public class CallActivity extends AppCompatActivity {
                 hideCallActivityProgressBar();
                 hideInLobbyWaitingOverlay();
                 showParticipantHeaderNotification();
+            } else if (callState == CallState.DISCONNECTED) {
+                if (localParticipantView != null && localParticipantView.getVisibility() == View.VISIBLE) {
+                    showRemovedFromTeamsMeetingAlertDialog();
+                }
             } else if (callState == CallState.NONE) {
                 if (inLobbyWaitingOverlay.getVisibility() == View.VISIBLE) {
                     showMeetingAccessDeniedAlertDialog();
-                } else if (localParticipantView != null && localParticipantView.getVisibility() == View.VISIBLE) {
-                    showRemovedFromTeamsMeetingAlertDialog();
                 }
             }
         };


### PR DESCRIPTION
After update to use calling SDK 1.0.1 beta1, there is a change for the call state which uses DISCONNECTED to replace NONE when after user leave the call or being removed from the call.


## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[X] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```
