### PR TITLE
Keep video off if joining a Teams meeting while video is on, but app is minimized

### DIFF
--- a/AzureCalling/app/src/main/java/com/azure/samples/communication/calling/activities/CallActivity.java
+++ b/AzureCalling/app/src/main/java/com/azure/samples/communication/calling/activities/CallActivity.java
@@ -261,14 +261,16 @@ public class CallActivity extends AppCompatActivity {
     @Override
     public void onStop() {
         Log.d(LOG_TAG, "CallActivity onStop");
-        callingContext.pauseVideo();
+        callingContext.pauseVideo().thenRun(() -> runOnUiThread(() ->
+                localParticipantView.setVideoStream((LocalVideoStream) null)));
         super.onStop();
     }
 
     @Override
     public void onResume() {
         Log.d(LOG_TAG, "CallActivity onResume");
-        callingContext.resumeVideo();
+        callingContext.resumeVideo().thenAccept(localVideoStream -> runOnUiThread(() ->
+                localParticipantView.setVideoStream(localVideoStream)));
         super.onResume();
     }
 

--- a/AzureCalling/app/src/main/java/com/azure/samples/communication/calling/external/calling/CallingContext.java
+++ b/AzureCalling/app/src/main/java/com/azure/samples/communication/calling/external/calling/CallingContext.java
@@ -237,23 +237,28 @@ public class CallingContext {
         }
 
         return getLocalVideoStreamCompletableFuture().thenCompose(localVideoStream ->
-                call.stopVideo(appContext, localVideoStream).thenRun(() -> cameraOn = false));
+                call.stopVideo(appContext, localVideoStream).thenRun(() -> {
+                    cameraOn = false;
+                }));
     }
 
-    public void pauseVideo() {
+    public CompletableFuture pauseVideo() {
         if (cameraOn && call != null) {
-            turnOffVideoAsync().thenRun(() -> {
+            return turnOffVideoAsync().thenRun(() -> {
                 isVideoOnHold = true;
             });
         }
+        return CompletableFuture.completedFuture(null);
     }
 
-    public void resumeVideo() {
+    public CompletableFuture<LocalVideoStream> resumeVideo() {
         if (isVideoOnHold && call != null) {
-            turnOnVideoAsync().thenRun(() -> {
+            return turnOnVideoAsync().thenApply(localVideoStream -> {
                 isVideoOnHold = false;
+                return localVideoStream;
             });
         }
+        return CompletableFuture.completedFuture(null);
     }
 
     public CompletableFuture turnOnAudioAsync() {


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* Keep video off if joining a Teams meeting while video is on, but app is minimized

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What to Check
Verify that the following are valid
1. Join Teams Meeting with video on
2. In the lobby, minimize the app
3. From the Teams meeting, allow the user in
4. Make sure that the user's video isn't on once the user is admitted
5. Make sure the user's video turns on once the user re-opens the app

## Other Information
<!-- Add any other helpful information that may be needed here. -->