### PR TITLE
Fix bug for the case off-screen user share screen

### DIFF
--- a/AzureCalling/app/src/main/java/com/azure/samples/communication/calling/external/calling/CallingContext.java
+++ b/AzureCalling/app/src/main/java/com/azure/samples/communication/calling/external/calling/CallingContext.java
@@ -512,16 +512,13 @@ public class CallingContext {
         final String username = remoteParticipant.getDisplayName();
         final String id = getId(remoteParticipant);
         final RemoteVideoStreamsUpdatedListener remoteVideoStreamsUpdatedListener = remoteVideoStreamsEvent -> {
-            if (!displayedRemoteParticipantIds.contains(id)) {
-                return;
-            }
             if (isSharingScreen(remoteParticipant)) {
                 currentScreenSharingParticipant = remoteParticipant;
-            } else {
-                if (currentScreenSharingParticipant != null
+            } else if (currentScreenSharingParticipant != null
                         && id.equals(getId(currentScreenSharingParticipant))) {
-                    currentScreenSharingParticipant = null;
-                }
+                currentScreenSharingParticipant = null;
+            } else if (!displayedRemoteParticipantIds.contains(id)) {
+                return;
             }
             displayedParticipantsLiveData.postValue(displayedRemoteParticipants);
             Log.d(LOG_TAG, String.format("Remote Participant %s addOnRemoteVideoStreamsUpdatedListener", username));


### PR DESCRIPTION
## Purpose
When there are more than 5 remote participants in the call, let a off-screen user turn on/off screen share will not see the expected thing on the mobile screen.
So I create this PR change to fix that.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[X] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
*  Get the code
* Start a call from web client with at least 6 participants
* join the call from mobile side
* turn on/off screen share from off-screen participant on the web client side
