### PR TITLE
Remove Unnecessary Checks when Switching Local Camera

### DIFF
--- a/AzureCalling/app/src/main/java/com/azure/samples/communication/calling/external/calling/CallingContext.java
+++ b/AzureCalling/app/src/main/java/com/azure/samples/communication/calling/external/calling/CallingContext.java
@@ -237,13 +237,7 @@ public class CallingContext {
                 desiredCamera = getFrontCamera();
             }
             localVideoStream.switchSource(desiredCamera).thenRun(() -> {
-                if (call != null) {
-                    call.startVideo(appContext, localVideoStream).thenRun(() -> {
-                        localVideoStreamCompletableFuture.complete(localVideoStream);
-                    });
-                } else {
-                    localVideoStreamCompletableFuture.complete(localVideoStream);
-                }
+                localVideoStreamCompletableFuture.complete(localVideoStream);
             });
         });
     }


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* Remove unnecessary logic for checking for a call object and starting the video 

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What to Check
Verify that the following are valid
* Ensure switching local camera is functioning on both Setup and Call screens
