### PR TITLE
fix CallingHero build issues, pin versions so they don't happen again

### DIFF
--- a/AzureCalling/app/build.gradle
+++ b/AzureCalling/app/build.gradle
@@ -3,7 +3,7 @@ plugins {
 }
 
 android {
-    compileSdk 32
+    compileSdk 33
 
     defaultConfig {
         applicationId "com.azure.samples.communication.calling"
@@ -60,11 +60,11 @@ android {
 
 dependencies {
 
-    implementation 'androidx.appcompat:appcompat:1.4.2'
-    implementation 'com.google.android.material:material:1.6.1'
+    implementation 'androidx.appcompat:appcompat:1.6.1'
+    implementation 'com.google.android.material:material:1.9.0'
     implementation 'androidx.constraintlayout:constraintlayout:2.1.4'
-    implementation 'com.azure.android:azure-communication-ui-calling:+'
-    implementation 'com.microsoft.identity.client:msal:+'
-    implementation 'com.microsoft.fluentui:FluentUIAndroid:+'
+    implementation 'com.azure.android:azure-communication-ui-calling:1.5.0-beta.1'
+    implementation 'com.microsoft.identity.client:msal:4.7.0'
+    implementation 'com.microsoft.fluentui:FluentUIAndroid:0.1.35'
     implementation 'com.android.volley:volley:1.2.1'
 }


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* Testing the Calling Hero, it didn't build. Because we used '+' in our Gradle versions, new versions of dependencies required a bump to the compile SDK Version. Updated the project and pinned the dependencies so it doesn't re-occur.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[ ] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
*  Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
npm install
```

* Test the code
<!-- Add steps to run the tests suite and/or manually test -->
```
```

## What to Check
Verify that the following are valid
* ...

## Other Information
<!-- Add any other helpful information that may be needed here. -->